### PR TITLE
Incremental Progress 2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
+### Pull Request #3 (08/01/2020)
 
+* Added `num_sims` parameter to POMCP/POUCT that allows specifying the number of simulations per planning step (Previously only `planning_time` was available.
+* Added cythonized versions of tiger and rocksample domains which are much faster.
 
-### Pull Request #1
+### Pull Request #1 (06/02/2020)
 
 * Added continuous light-dark domain. A solver (BLQR) is attempted but not ready yet.
 * Bug fix in 2D MOS domain rollout; action step size changeable

--- a/pomdp_problems/rocksample/cythonize/run_rocksample.py
+++ b/pomdp_problems/rocksample/cythonize/run_rocksample.py
@@ -1,0 +1,4 @@
+from rocksample_problem import main
+
+if __name__ == "__main__":
+    main()

--- a/pomdp_problems/tiger/cythonize/run_tiger.py
+++ b/pomdp_problems/tiger/cythonize/run_tiger.py
@@ -1,0 +1,4 @@
+from tiger_problem import main
+
+if __name__ == "__main__":
+    main()

--- a/pomdp_problems/tiger/tiger_problem.py
+++ b/pomdp_problems/tiger/tiger_problem.py
@@ -254,6 +254,7 @@ def test_planner(tiger_problem, planner, nsteps=3):
         planner.update(tiger_problem.agent, action, real_observation)
         if isinstance(planner, pomdp_py.POUCT):
             print("Num sims: %d" % planner.last_num_sims)
+            print("Plan time: %.5f" % planner.last_planning_time)
         if isinstance(tiger_problem.agent.cur_belief, pomdp_py.Histogram):
             new_belief = pomdp_py.update_histogram_belief(tiger_problem.agent.cur_belief,
                                                           action, real_observation,
@@ -363,7 +364,7 @@ def main():
 
     print("** Testing POUCT **")
     pouct = pomdp_py.POUCT(max_depth=10, discount_factor=0.95,
-                           planning_time=.5, exploration_const=110,
+                           planning_time=0.5, exploration_const=110,
                            rollout_policy=tiger_problem.agent.policy_model)
     test_planner(tiger_problem, pouct, nsteps=10)
 
@@ -377,7 +378,7 @@ def main():
     print("** Testing POMCP **")
     tiger_problem.agent.set_belief(pomdp_py.Particles.from_histogram(init_belief, num_particles=100), prior=True)
     pomcp = pomdp_py.POMCP(max_depth=10, discount_factor=0.95,
-                           planning_time=.5, exploration_const=110,
+                           num_sims=1000, exploration_const=110,
                            rollout_policy=tiger_problem.agent.policy_model)
     test_planner(tiger_problem, pomcp, nsteps=10)
     

--- a/pomdp_py/algorithms/po_rollout.pyx
+++ b/pomdp_py/algorithms/po_rollout.pyx
@@ -33,12 +33,12 @@ cdef class PORollout(Planner):
     """
 
     def __init__(self,
-                 num_simulations=100,
+                 num_sims=100,
                  max_depth=5, discount_factor=0.9,
                  rollout_policy=RandomRollout(),
                  particles=False,  # true if use Monte-Carlo belief update
                  action_prior=None):
-        self._num_sims = num_simulations
+        self._num_sims = num_sims
         self._max_depth = max_depth
         self._rollout_policy = rollout_policy
         self._action_prior = action_prior

--- a/pomdp_py/algorithms/po_uct.pxd
+++ b/pomdp_py/algorithms/po_uct.pxd
@@ -18,6 +18,7 @@ cdef class RootVNode(VNode):
 cdef class POUCT(Planner):
     cdef int _max_depth
     cdef float _planning_time
+    cdef int _num_sims
     cdef int _num_visits_init
     cdef float _value_init
     cdef float _discount_factor
@@ -26,11 +27,12 @@ cdef class POUCT(Planner):
     cdef RolloutPolicy _rollout_policy
     cdef Agent _agent
     cdef int _last_num_sims
+    cdef float _last_planning_time    
 
     cpdef _search(self)
     cpdef _simulate(POUCT self,
-                          State state, tuple history, VNode root, QNode parent,
-                          Observation observation, int depth)
+                    State state, tuple history, VNode root, QNode parent,
+                    Observation observation, int depth)
 
     cpdef _expand_vnode(self, VNode vnode, tuple history, State state=*)
     cpdef _rollout(self, State state, tuple history, VNode root, int depth)

--- a/pomdp_py/algorithms/po_uct.pyx
+++ b/pomdp_py/algorithms/po_uct.pyx
@@ -270,6 +270,10 @@ cdef class POUCT(Planner):
         return self._last_planning_time
 
     cpdef public plan(self, Agent agent):
+        cdef Action action
+        cdef float time_taken
+        cdef int sims_count
+    
         self._agent = agent   # switch focus on planning for the given agent
         if not hasattr(self._agent, "tree"):
             self._agent.add_attr("tree", None)

--- a/pomdp_py/algorithms/pomcp.pyx
+++ b/pomdp_py/algorithms/pomcp.pyx
@@ -60,7 +60,7 @@ cdef class POMCP(POUCT):
     with action space that can be enumerated."""
 
     def __init__(self,
-                 max_depth=5, planning_time=1.,
+                 max_depth=5, planning_time=-1., num_sims=-1,
                  discount_factor=0.9, exploration_const=math.sqrt(2),
                  num_visits_init=1, value_init=0,
                  rollout_policy=RandomRollout(),
@@ -71,6 +71,7 @@ cdef class POMCP(POUCT):
         """
         super().__init__(max_depth=max_depth,
                          planning_time=planning_time,
+                         num_sims=num_sims,
                          discount_factor=discount_factor,
                          exploration_const=exploration_const,
                          num_visits_init=num_visits_init,

--- a/setup.py
+++ b/setup.py
@@ -30,6 +30,8 @@ setup(name='pomdp-py',
                              'pomdp_py/representations/distribution/particles.pyx',
                              'pomdp_py/representations/distribution/histogram.pyx',
                              'pomdp_py/representations/distribution/gaussian.pyx',
-                             'pomdp_py/representations/belief/particles.pyx'],
+                             'pomdp_py/representations/belief/particles.pyx',
+                             'pomdp_problems/tiger/cythonize/tiger_problem.pyx',
+                             'pomdp_problems/rocksample/cythonize/rocksample_problem.pyx'],
                             build_dir="build", compiler_directives={'language_level' : "3"})
      )


### PR DESCRIPTION
* Added `num_sims` parameter to POMCP/POUCT that allows specifying the number of simulations per planning step (Previously only `planning_time` was available.

* Added cythonized versions of tiger and rocksample domains which are much faster.