### PR TITLE
Pin Cython version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,7 @@ setup(name='pomdp-py',
       long_description=long_description,
       long_description_content_type="text/x-rst",
       install_requires=[
-          'Cython',
+          'Cython==3.0.8',
           'numpy',
           'scipy',
           'tqdm',


### PR DESCRIPTION
I cannot pip install on macOS 14.2.1 with M2 unless I pin the Cython version...