### PR TITLE
Add macOS build

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -1,0 +1,45 @@
+name: pomdp-py macOS build
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: macos-latest
+    strategy:
+      fail-fast: true
+    steps:
+    - uses: actions/checkout@v4
+    - uses: actions/setup-python@v5
+      with:
+        python-version: '3.10'
+    - name: Build dependencies
+      run: |
+        # Install pomdp-solve macOS binary
+        wget -P thirdparty https://www.pomdp.org/code/pomdp-solve-os-x.bin
+        chmod +x thirdparty/pomdp-solve-os-x.bin
+
+        # Build and install SARSOP
+        git clone https://github.com/personalrobotics/appl.git thirdparty/appl
+        # Fix Arm build (remove -mfpmath=sse) and declare implict functions
+        git -C thirdparty/appl apply ../../tests/appl.patch
+        make -C thirdparty/appl/src
+        make -C thirdparty/appl/src install
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install -e .
+    - name: Test
+      working-directory: .
+      run: |
+        export POMDP_SOLVE_PATH=./thirdparty/pomdp-solve-os-x.bin
+        export POMDPSOL_PATH=./thirdparty/appl/bin/pomdpsol
+        export POMDPCONVERT_PATH=./thirdparty/appl/src/pomdpconvert
+        python tests/test_all.py

--- a/.github/workflows/pre_commit.yml
+++ b/.github/workflows/pre_commit.yml
@@ -1,0 +1,17 @@
+name: Pre-Commit
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
+
+jobs:
+  pre-commit:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - uses: actions/setup-python@v3
+    - uses: pre-commit/action@v3.0.0

--- a/.gitignore
+++ b/.gitignore
@@ -60,7 +60,6 @@ Demos/*/*.html
 /dist/
 .gitrev
 .coverage
-*.patch
 *.diff
 *.orig
 *.prof
@@ -135,3 +134,5 @@ Thumbs.db
 #############################
 *.alpha
 *.pg
+
+.DS_Store

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,3 +1,5 @@
+exclude: '^tests/appl.patch$'
+
 fail_fast: false
 repos:
 -   repo: https://github.com/pre-commit/pre-commit-hooks

--- a/pomdp_py/__main__.py
+++ b/pomdp_py/__main__.py
@@ -9,8 +9,9 @@ def parse_args():
         "-r",
         "--run",
         type=str,
-        help="run a pomdp under pomdp_py.problems."
-        "Available options: {}".format(available_problems),
+        help="run a pomdp under pomdp_py.problems.Available options: {}".format(
+            available_problems
+        ),
     )
     args = parser.parse_args()
     return parser, args

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 
-from setuptools import setup, Extension
+from setuptools import setup, Extension, find_packages
 from Cython.Build import cythonize
 import os.path
 
@@ -41,6 +41,7 @@ setup(
     ext_modules=cythonize(
         extensions, build_dir="build", compiler_directives={"language_level": "3"}
     ),
+    packages=find_packages(exclude=["thirdparty", "thirdparty.*"]),
     package_data={
         "pomdp_py": ["*.pxd", "*.pyx", "*.so", "*.c"],
         "pomdp_problems": ["*.pxd", "*.pyx", "*.so", "*.c"],

--- a/tests/appl.patch
+++ b/tests/appl.patch
@@ -1,0 +1,77 @@
+diff --git a/src/Makefile b/src/Makefile
+index 456cef1..a58539b 100644
+--- a/src/Makefile
++++ b/src/Makefile
+@@ -57,7 +57,7 @@ endif
+ 
+ CC            = gcc
+ 
+-CFLAGS        = -g -w -O3 $(INCDIR) -msse2  -mfpmath=sse $(CYGWIN_CFLAGS)  #-DDEBUG_LOG_ON
++CFLAGS        = -g -w -O3 $(INCDIR) -msse2 $(CYGWIN_CFLAGS)  #-DDEBUG_LOG_ON
+ 
+ CXX           = g++
+ 
+diff --git a/src/Parser/Cassandra/decision-tree.h b/src/Parser/Cassandra/decision-tree.h
+index 9005cef..90da271 100644
+--- a/src/Parser/Cassandra/decision-tree.h
++++ b/src/Parser/Cassandra/decision-tree.h
+@@ -23,13 +23,13 @@ permissions and limitations under the License.
+ 
+ #ifndef INCdecision_tree_h
+ #define INCdecision_tree_h
+-
+-#include "Const.h"
+-
+-#ifdef __cplusplus
+-extern "C" {
+-#endif 
+-
++
++#include "Const.h"
++
++#ifdef __cplusplus
++extern "C" {
++#endif 
++
+ 
+ 	/**********************************************************************
+ 	See an example of how to use this library in testDecisionTree.c.
+@@ -70,9 +70,11 @@ extern "C" {
+ 	stdout.  Intended for debugging. */
+ 	extern void dtDebugPrint(const char* header);
+ 
+-#ifdef __cplusplus
+-}
+-#endif 
++	extern void checkAllocatedPointer(void * ptr);
++
++#ifdef __cplusplus
++}
++#endif 
+ 
+ 
+ 
+diff --git a/src/Parser/Cassandra/parse_err.h b/src/Parser/Cassandra/parse_err.h
+index f2f60bf..01665ba 100644
+--- a/src/Parser/Cassandra/parse_err.h
++++ b/src/Parser/Cassandra/parse_err.h
+@@ -157,6 +157,7 @@ void ERR_enter(	char 	*source,
+ 			char	*modificationString );
+ void ERR_initialize(void);
+ void ERR_cleanUp(void);
++void checkAllocatedPointer(void * ptr);
+ 
+ #ifdef __cplusplus
+ }  /* extern "C" */
+diff --git a/src/Parser/Cassandra/sparse-matrix.h b/src/Parser/Cassandra/sparse-matrix.h
+index 68ae1d1..7324db6 100644
+--- a/src/Parser/Cassandra/sparse-matrix.h
++++ b/src/Parser/Cassandra/sparse-matrix.h
+@@ -100,6 +100,7 @@ extern Matrix transformIMatrix( I_Matrix i_matrix );
+ extern void displayMatrix( Matrix matrix );
+ extern REAL_VALUE sumRowValues( Matrix matrix, int row );
+ extern REAL_VALUE getEntryMatrix( Matrix matrix, int row, int col );
++extern void checkAllocatedPointer(void * ptr);
+ 
+ #ifdef __cplusplus
+ }  /* extern "C" */


### PR DESCRIPTION
This PR adds a macOS CI build. 

The current Ubuntu build is not particularly meaningful because it does not install external dependencies and skips several tests. I addressed this by:
- Downloading the `pomdp-solve` macOS binary. I attempted to build it from source but was unsuccessful (in both Ubuntu and macOS). I did not try the Ubuntu binary.
- Building SARSOP (specifically, the fork for macOS) from source. Binaries are not supplied, and I had to make some modifications to the source code in order to build it successfully (the changes are saved as `tests/appl.patch`). I couldn't build it in Ubuntu (but didn't try very hard)
- Exported `POMDP_SOLVE_PATH`, `POMDPCONVERT_PATH`, and `POMDP_SOLVE_PATH`. I think it's useful for these to exist in script form.
- Added a CI check for pre-commit

Right now all 7 unit tests pass under macOS. I believe these are important features to facilitate future contributions to `pomdp-py`.