### PR TITLE
Retain pomdp-solve in CI but not submodule for simplicity of repo

### DIFF
--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -27,6 +27,7 @@ jobs:
         # build pomdp-solve
         sudo apt-get update
         sudo apt-get install -y autoconf automake libtool
+        git clone https://github.com/cassandra/pomdp-solve.git thirdparty/
         cd thirdparty/pomdp-solve
         ./configure
         make

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -27,7 +27,7 @@ jobs:
         # build pomdp-solve
         sudo apt-get update
         sudo apt-get install -y autoconf automake libtool
-        git clone https://github.com/cassandra/pomdp-solve.git thirdparty/pomdp-py
+        git clone https://github.com/cassandra/pomdp-solve.git thirdparty/pomdp-solve
         cd thirdparty/pomdp-solve
         ./configure
         make

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -27,8 +27,9 @@ jobs:
         # build pomdp-solve
         sudo apt-get update
         sudo apt-get install -y autoconf automake libtool
+        commit_hash=4f5d399f260f7789bc1d95baab069eef5c93aaf9
         git clone https://github.com/cassandra/pomdp-solve.git thirdparty/pomdp-solve
-        cd thirdparty/pomdp-solve
+        cd thirdparty/pomdp-solve && git checkout $commit_hash
         ./configure
         make
     - name: Install dependencies

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -27,7 +27,7 @@ jobs:
         # build pomdp-solve
         sudo apt-get update
         sudo apt-get install -y autoconf automake libtool
-        git clone https://github.com/cassandra/pomdp-solve.git thirdparty/
+        git clone https://github.com/cassandra/pomdp-solve.git thirdparty/pomdp-py
         cd thirdparty/pomdp-solve
         ./configure
         make

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "thirdparty/pomdp-solve"]
-	path = thirdparty/pomdp-solve
-	url = git@github.com:cassandra/pomdp-solve.git


### PR DESCRIPTION
Simplify the repo by maintaining only the CI test showcasing pomdp-py's integration with the external library pomdp-solve.