### PR TITLE
A Response and Response model

### DIFF
--- a/pomdp_py/algorithms/po_rollout.pxd
+++ b/pomdp_py/algorithms/po_rollout.pxd
@@ -1,4 +1,4 @@
-from pomdp_py.framework.basics cimport Action, State, Observation, Agent
+from pomdp_py.framework.basics cimport Action, State, Observation, Agent, Response
 from pomdp_py.framework.planner cimport Planner
 from pomdp_py.algorithms.po_uct cimport RolloutPolicy, ActionPrior
 
@@ -11,7 +11,7 @@ cdef class PORollout(Planner):
     cdef float _discount_factor
     cdef bint _particles
     cdef Agent _agent
-    cdef float _last_best_reward
+    cdef Response _last_best_response
 
     cpdef _search(self)
     cpdef _rollout(self, State state, int depth)

--- a/pomdp_py/algorithms/po_uct.pxd
+++ b/pomdp_py/algorithms/po_uct.pxd
@@ -1,5 +1,5 @@
 from pomdp_py.framework.planner cimport Planner
-from pomdp_py.framework.basics cimport Agent, PolicyModel, Action, State, Observation
+from pomdp_py.framework.basics cimport Agent, PolicyModel, Action, State, Observation, Response
 
 cdef class TreeNode:
     cdef public dict children
@@ -7,10 +7,11 @@ cdef class TreeNode:
     cdef public float value
 
 cdef class QNode(TreeNode):
-    pass
+    cpdef void update(QNode self, Response response)
 
 cdef class VNode(TreeNode):
     cpdef argmax(VNode self)
+    cpdef void update(VNode self)
 
 cdef class RootVNode(VNode):
     cdef public tuple history

--- a/pomdp_py/algorithms/pomcp.pyx
+++ b/pomdp_py/algorithms/pomcp.pyx
@@ -128,10 +128,10 @@ cdef class POMCP(POUCT):
     cpdef _simulate(POMCP self,
                     State state, tuple history, VNode root, QNode parent,
                     Observation observation, int depth):
-        total_reward = POUCT._simulate(self, state, history, root, parent, observation, depth)
+        total_response = POUCT._simulate(self, state, history, root, parent, observation, depth)
         if depth == 1 and root is not None:
             root.belief.add(state)  # belief update happens as simulation goes.
-        return total_reward
+        return total_response
 
     def _VNode(self, root=False, **kwargs):
         """Returns a VNode with default values; The function naming makes it clear

--- a/pomdp_py/algorithms/value_iteration.pyx
+++ b/pomdp_py/algorithms/value_iteration.pyx
@@ -48,8 +48,8 @@ cdef class _PolicyTreeNode:
                         subtree_value = self.children[o].values[sp]  # corresponds to V_{oi(p)} in paper
                     else:
                         subtree_value = 0.0
-                    reward = self._agent.reward_model.sample(s, self.action, sp)
-                    expected_future_value += trans_prob * obsrv_prob * (reward + discount_factor*subtree_value)
+                    response = self._agent.response_model.sample(s, self.action, sp)
+                    expected_future_value += trans_prob * obsrv_prob * (response["reward"] + discount_factor*subtree_value)
             values[s] = expected_future_value
         return values
 

--- a/pomdp_py/framework/basics.pxd
+++ b/pomdp_py/framework/basics.pxd
@@ -8,6 +8,10 @@ cdef class TransitionModel:
     pass
 cdef class PolicyModel:
     pass
+    
+cdef class ResponseModel(dict):
+    pass
+
 cdef class BlackboxModel:
     pass
 cdef class RewardModel:
@@ -27,6 +31,12 @@ cdef class State:
 cdef class Observation:
     pass
 
+cdef class Vector(list):
+    pass
+
+cdef class Response(dict):
+    pass
+
 cdef class Agent:
     cdef GenerativeDistribution _init_belief
     cdef PolicyModel _policy_model
@@ -41,7 +51,7 @@ cdef class Agent:
 cdef class Environment:
     cdef State _init_state
     cdef TransitionModel _transition_model
-    cdef RewardModel _reward_model
+    cdef ResponseModel _response_model
     cdef BlackboxModel _blackbox_model
     cdef State _cur_state
 
@@ -49,4 +59,4 @@ cdef class Option(Action):
     pass
 
 cpdef sample_generative_model(Agent agent, State state, Action action, float discount_factor=*)
-cpdef sample_explict_models(TransitionModel T, ObservationModel O, RewardModel R, State state, Action a, float discount_factor=*)
+cpdef sample_explict_models(TransitionModel T, ObservationModel O, ResponseModel R, State state, Action a, float discount_factor=*)

--- a/pomdp_py/framework/basics.pyx
+++ b/pomdp_py/framework/basics.pyx
@@ -197,6 +197,17 @@ cdef class ResponseModel:
     
     @staticmethod
     def generate_response_model(model_dict, response=Response()):
+        """
+        Generate a response model based on a dictionary of model attributes. This is a 
+        convenience method to make it easier to build a Response model.
+         
+        Args:
+         	model_dict (dict): A dictionary of models in the form {model_type: model} (e.g., {reward: reward_model})
+         	response (Response): A response that will be used to generate new responses.
+         
+        Returns: 
+         	The response model.
+        """
         # Do a sanity check to ensure the response model and response are compatible.
         for name in model_dict.keys():
             if not hasattr(response, name):
@@ -208,6 +219,12 @@ cdef class ResponseModel:
         return model
 
     def add_attrs(self, attr_dict):
+        """
+        Adds attributes to this object dynamically.
+
+         Args:
+         	attr_dict: A dictionary of attribute names and values.
+        """
         if not isinstance(attr_dict, dict):
             raise TypeError(f"attr_dict must be type dict, but got {type(attr_dict)}.")
 
@@ -217,6 +234,12 @@ cdef class ResponseModel:
             setattr(self, ak, None)
 
     def add_models(self, model_dict):
+        """
+        Add models to the response.
+        
+        Args:
+         	model_dict: A dictionary of models in the form {model_type: model} (e.g., {reward: reward_model}).
+        """
         if not isinstance(model_dict, dict):
             raise TypeError(f"model_dict must be type dict, but got {type(model_dict)}.")
 
@@ -249,11 +272,13 @@ cdef class ResponseModel:
         ]))
 
     def create_response(self, *args, **kwargs):
+        """
+        Create a response with the given arguments.
+         
+        Returns: 
+         	An instance of : class : ` Response ` with the given parameters.
+        """
         return self._response.new(*args, **kwargs)
-
-    # @property
-    # def response_type(self):
-    #     return type(self._response_type)
 
 cdef class BlackboxModel:
     """
@@ -387,6 +412,9 @@ cdef class Observation:
         return not self.__eq__(other)
 
 cdef class Vector(list):
+    """
+    The Vector class. Provides an implementation of a vector for multi-valued response models.
+    """
     def __init__(self, values=list()):
         if not isinstance(values, list):
             raise TypeError(f"values must be type list, but got {type(values)}.")

--- a/pomdp_py/problems/load_unload/load_unload.py
+++ b/pomdp_py/problems/load_unload/load_unload.py
@@ -220,10 +220,10 @@ class LoadUnloadProblem(pomdp_py.POMDP):
             LUPolicyModel(),
             LUTransitionModel(),
             LUObservationModel(),
-            LURewardModel(),
+            pomdp_py.ResponseModel({"reward": LURewardModel()}),
         )
 
-        env = pomdp_py.Environment(init_state, LUTransitionModel(), LURewardModel())
+        env = pomdp_py.Environment(init_state, LUTransitionModel(), pomdp_py.ResponseModel({"reward": LURewardModel()}))
 
         super().__init__(agent, env, name="LoadUnloadProblem")
 
@@ -267,7 +267,8 @@ def test_planner(load_unload_problem, planner, nsteps=3, discount=0.95):
         print("==== Step %d ====" % (t + 1))
         action = planner.plan(load_unload_problem.agent)
 
-        env_reward = load_unload_problem.env.state_transition(action, execute=True)
+        env_response = load_unload_problem.env.state_transition(action, execute=True)
+        env_reward = env_response["reward"]
         true_state = copy.deepcopy(load_unload_problem.env.state)
 
         real_observation = load_unload_problem.env.provide_observation(

--- a/pomdp_py/problems/multi_object_search/agent/agent.py
+++ b/pomdp_py/problems/multi_object_search/agent/agent.py
@@ -60,7 +60,7 @@ class MosAgent(pomdp_py.Agent):
             policy_model,
             transition_model=transition_model,
             observation_model=observation_model,
-            reward_model=reward_model,
+            response_model=pomdp_py.ResponseModel({"reward": reward_model}),
         )
 
     def clear_history(self):

--- a/pomdp_py/problems/multi_object_search/env/env.py
+++ b/pomdp_py/problems/multi_object_search/env/env.py
@@ -33,7 +33,7 @@ class MosEnvironment(pomdp_py.Environment):
             if not isinstance(init_state.object_states[objid], RobotState)
         }
         reward_model = GoalRewardModel(self.target_objects)
-        super().__init__(init_state, transition_model, reward_model)
+        super().__init__(init_state, transition_model, pomdp_py.ResponseModel({"reward": reward_model}))
 
     @property
     def robot_ids(self):
@@ -52,8 +52,8 @@ class MosEnvironment(pomdp_py.Environment):
                             become the current state.
 
         Returns:
-            float or tuple: reward as a result of `action` and state
-            transition, if `execute` is True (next_state, reward) if `execute`
+            Response or tuple: response as a result of `action` and state
+            transition, if `execute` is True (next_state, response) if `execute`
             is False.
 
         """
@@ -66,9 +66,10 @@ class MosEnvironment(pomdp_py.Environment):
             self.state, action
         )
 
-        reward = self.reward_model.sample(
+        response = self.response_model.sample(
             self.state, action, next_state, robot_id=robot_id
         )
+        reward = response["reward"]
         if execute:
             self.apply_transition(next_state)
             return reward

--- a/pomdp_py/problems/tag/agent/agent.py
+++ b/pomdp_py/problems/tag/agent/agent.py
@@ -118,7 +118,7 @@ class TagAgent(pomdp_py.Agent):
             policy_model,
             transition_model=transition_model,
             observation_model=observation_model,
-            reward_model=reward_model,
+            response_model=pomdp_py.ResponseModel({"reward": reward_model}),
         )
 
     def clear_history(self):

--- a/pomdp_py/problems/tag/env/env.py
+++ b/pomdp_py/problems/tag/env/env.py
@@ -14,7 +14,7 @@ class TagEnvironment(pomdp_py.Environment):
         target_motion_policy = TagTargetMotionPolicy(grid_map, pr_stay)
         transition_model = TagTransitionModel(grid_map, target_motion_policy)
         reward_model = TagRewardModel(small=small, big=big)
-        super().__init__(init_state, transition_model, reward_model)
+        super().__init__(init_state, transition_model, pomdp_py.ResponseModel({"reward": reward_model}))
 
     @property
     def width(self):

--- a/pomdp_py/problems/tag/problem.py
+++ b/pomdp_py/problems/tag/problem.py
@@ -87,7 +87,7 @@ def solve(
             break  # no more time to update.
 
         # Execute action
-        reward = problem.env.state_transition(real_action, execute=True)
+        response = problem.env.state_transition(real_action, execute=True)
 
         # Receive observation
         _start = time.time()
@@ -104,13 +104,13 @@ def solve(
         _time_used += time.time() - _start
 
         # Info and render
-        _total_reward += reward
-        _total_discounted_reward += reward * _discount
+        _total_reward += response["reward"]
+        _total_discounted_reward += response["reward"] * _discount
         _discount = _discount * discount_factor
         print("==== Step %d ====" % (i + 1))
         print("Action: %s" % str(real_action))
         print("Observation: %s" % str(real_observation))
-        print("Reward: %s" % str(reward))
+        print("Reward: %s" % str(response["reward"]))
         print("Reward (Cumulative): %s" % str(_total_reward))
         print("Reward (Discounted): %s" % str(_total_discounted_reward))
         print("Find Actions Count: %d" % _find_actions_count)

--- a/pomdp_py/problems/tiger/tiger_problem.py
+++ b/pomdp_py/problems/tiger/tiger_problem.py
@@ -217,9 +217,9 @@ class TigerProblem(pomdp_py.POMDP):
             PolicyModel(),
             TransitionModel(),
             ObservationModel(obs_noise),
-            RewardModel(),
+            pomdp_py.ResponseModel({"reward": RewardModel()}),
         )
-        env = pomdp_py.Environment(init_true_state, TransitionModel(), RewardModel())
+        env = pomdp_py.Environment(init_true_state, TransitionModel(), pomdp_py.ResponseModel({"reward": RewardModel()}))
         super().__init__(agent, env, name="TigerProblem")
 
     @staticmethod
@@ -273,7 +273,7 @@ def test_planner(tiger_problem, planner, nsteps=3, debug_tree=False):
         # in real world); In that case, you could skip
         # the state transition and re-estimate the state
         # (e.g. through the perception stack on the robot).
-        reward = tiger_problem.env.reward_model.sample(
+        reward = tiger_problem.env.response_model["reward"].sample(
             tiger_problem.env.state, action, None
         )
         print("Reward:", reward)

--- a/tests/test_response.py
+++ b/tests/test_response.py
@@ -1,0 +1,41 @@
+from pomdp_py.framework.basics import Response, Vector
+
+description = "testing framework basics response"
+
+
+def test_assign():
+    r = Response()
+    assert r["reward"] == 0.0
+    
+    r = Response({"reward": 34.0, "cost": Vector([12.0, 53.0])})
+    assert r["reward"] == 34.0
+    assert r["cost"] == [12.0, 53.0]
+    
+    
+def test_add():
+    r = Response()
+    r = r + Response({"reward": 42.0})
+    assert r["reward"] == 42.0
+    
+    r = Response({"reward": 42.0, "cost": Vector([4.0, 9.0])})
+    r = r + Response({"reward": 2.0, "cost": Vector([1.0, 2.0])})
+    assert r["reward"] == 44.0
+    assert r["cost"] == Vector([5.0, 11.0])
+    
+
+def test_multiply():
+    r = Response({"reward": 1.0, "cost": Vector([3.5, 6.2, 9.1])})
+    r = r * 1000.0
+    assert r["reward"] == 1000.0
+    assert r["cost"] == [3500.0, 6200.0, 9100.0]
+    
+    
+def run():
+    test_assign()
+    test_add()
+    test_multiply()
+    
+
+if __name__ == "__main__":
+    run()
+    


### PR DESCRIPTION
This pull request is the first stage of implementing the cost-constrained POMCP (CC-POMCP) algorithm. This algorithm cannot be added to the repository directly because it has additional variables and operations not present in the PO-UCT and POMCP algorithms. One example is cost constraints and their corresponding operations.

To accommodate costs and other future variables, I propose to use a generic model, called a Response model, and a corresponding output, called a response. The name "response" comes from the notion of independent and dependent variables, where a response (reward, cost, etc.) _depends_ on the interaction with the real or simulated environment. Thus, a response model is a wrapper for more specific models, such as reward and cost models (and any others that will follow in the future). By extension, a response is a wrapper for the reward, cost, etc.

The pull request has the following:

1. Implementation of the `ResponseModel` and `Response` classes in the basics files,
2. Updates to classes in basics to use `ResponseModel` instead of `RewardModel` directly,
3. Updates to the appropriate pre-existing algorithms, including PO-UCT and POMCP,
4. Updates to the code for the `tiger`, `rocksample`, `mos`, `load_unload`, and `tag` problems,
5. Added test script for response arithmetic operations in `test_response.py`,
6. Passes for the `test_all.py` script,
7. Passes for the `tiger`, `rocksample`, `mos`, `load_unload`, and `tag` problems.
8. Comments to the `ResponseModel` and `Response` classes.