### PR TITLE
Minor fix in rocksample_problem.py

### DIFF
--- a/pomdp_py/problems/rocksample/rocksample_problem.py
+++ b/pomdp_py/problems/rocksample/rocksample_problem.py
@@ -538,7 +538,7 @@ def create_instance(n, k, **kwargs):
 
 
 def main():
-    rocksample = debug_instance()  # create_instance(7, 8)
+    rocksample = create_instance(5, 5)
     rocksample.print_state()
 
     print("*** Testing POMCP ***")


### PR DESCRIPTION
Currently running `python -m pomdp_py -r rocksample` throws an exception
```
Traceback (most recent call last):
  File "/usr/local/lib/python3.10/runpy.py", line 196, in _run_module_as_main
    return _run_code(code, main_globals, None,
  File "/usr/local/lib/python3.10/runpy.py", line 86, in _run_code
    exec(code, run_globals)
  File "/home/kaiyu/pyenv/py310/lib/python3.10/site-packages/pomdp_py/__main__.py", line 31, in <module>
    main()
  File "/home/kaiyu/pyenv/py310/lib/python3.10/site-packages/pomdp_py/problems/rocksample/rocksample_problem.py",
 line 541, in main
    rocksample = debug_instance()  # create_instance(7, 8)
NameError: name 'debug_instance' is not defined. Did you mean: 'create_instance'?
```
This PR fixes that.