### PR TITLE
Fixing macos CI

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -29,15 +29,16 @@ jobs:
     - name: Build dependencies
       shell: bash
       run: |
-        # pomdp-solve (native)
+        # pomdp-solve (native, via autotools)
         mkdir -p thirdparty
         curl -L https://www.pomdp.org/code/pomdp-solve-5.5.tar.gz -o thirdparty/pomdp-solve-5.5.tar.gz
         tar -xzf thirdparty/pomdp-solve-5.5.tar.gz -C thirdparty
         mv thirdparty/pomdp-solve-5.5 thirdparty/pomdp-solve
+        ( cd thirdparty/pomdp-solve && ./configure )
         make -C thirdparty/pomdp-solve/src
         ln -sf "$(pwd)/thirdparty/pomdp-solve/src/pomdp-solve" thirdparty/pomdp-solve.bin
 
-        # APPL / SARSOP
+        # APPL / SARSOP (strip x86-only flags on arm64)
         git clone https://github.com/personalrobotics/appl.git thirdparty/appl
         git -C thirdparty/appl apply ../../tests/appl.patch
         if [[ $(uname -m) == "arm64" ]]; then


### PR DESCRIPTION
This fixes  error encountered with macOS CI (example run: https://github.com/h2r/pomdp-py/actions/runs/18796751957/job/53637789176?pr=85) 
```
g++ -g -w -O3 -I./MathLib -I./Algorithms -I./Algorithms/HSVI -I./Algorithms/SARSOP -I./Models/MOMDP/ -I./Models/MOMDP/CoLoc/ -I./OfflineSolver/ -I./Bounds/ -I./Core/ -I./Parser/Cassandra/ -I./Parser/Cassandra/include -I./Parser/ -I./Parser/POMDPX/ -I./Utils/ -I./Simulator/ -I./Evaluator/ -I./Controller/  -msse2      -c -o PolicyGraph/PolicyGraph.o PolicyGraph/PolicyGraph.cpp
clang++: error: unsupported option '-msse2' for target 'arm64-apple-darwin24.6.0'
make: *** [PolicyGraph/PolicyGraph.o] Error 1
```
by building pomdp-solve and sarsop from source on the now arm64-based `macos-latest` runner ([github docs](https://docs.github.com/en/actions/reference/runners/github-hosted-runners?versionId=free-pro-team%40latest&productId=actions&restPage=concepts%2Crunners%2Cgithub-hosted-runners#standard-github-hosted-runners-for-public-repositories)).